### PR TITLE
Fix pug-html-loader syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ module.exports = {
       {
         test: /\.pug/,
         loader: 'pug-html', 
-        query: { doctype: 'html', plugins: [require('pug-plugin-ng')] },
+        query: { doctype: 'html', plugins: ['pug-plugin-ng'] },
       },
     ]
   ]
@@ -94,7 +94,7 @@ If you have multiple loaders chained it can be written like this.
         include: helpers.root('modules'),
         loaders: [
           { loader: 'html', query: { root: 'images' } },
-          { loader: 'pug-html', query: { doctype: 'html', plugins: [require('pug-plugin-ng')] }},
+          { loader: 'pug-html', query: { doctype: 'html', plugins: ['pug-plugin-ng'] }},
         ]
       },
 ```


### PR DESCRIPTION
Looks like pug-html-loader plugins should be package name strings.

https://github.com/willyelm/pug-html-loader/blob/0d63e3260df525325e375d2cf021ce5677a7c1c2/lib/index.js#L27