### PR TITLE
Loosen restriction on pug version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
     "character-parser": "^2.1.1"
   },
   "devDependencies": {
-    "pug": "^2.0.0-beta5"
+    "pug": "^2.0.0-beta1"
   },
   "peerDependencies": {
-    "pug": "^2.0.0-beta5"
+    "pug": "^2.0.0-beta1"
   }
 }


### PR DESCRIPTION
Becuase Pug did not follow node-semver for their beta versions, NPM thinks that `beta10 < beta5`. What they should have done is called it `beta.X`. Changing the requirement to `^2.0.0-beta1` fixes an unmet peerDependency error when upgrading Pug.